### PR TITLE
Deps: jsonwebtoken@5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   "author": "Auth0",
   "license": "MIT",
   "dependencies": {
-    "jsonwebtoken": "^4.2.2"
+    "jsonwebtoken": "^5.0.0"
   },
   "devDependencies": {
     "chai": "^2.2.0",
-    "jws": "^2.0.0",
+    "jws": "^3.0.0",
     "mocha": "^2.2.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ module.exports = function(credentials){
 
     return jwt.sign(payload,
       new Buffer(credentials.clientSecret, 'base64').toString('binary'), {
-        expiresInSeconds: lifetimeInSeconds,
+        expiresIn: lifetimeInSeconds,
         audience: credentials.clientId,
         noTimestamp: true // we generate it before for the `jti`
       });


### PR DESCRIPTION
Bump up `jsonwebtoken` version, in the new version it uses a secure version of `jws`.
This library was not affected anyway because it only uses the signing capability. The problem in `jws` was verifying.

The PR changed the deprecated property `expiresInSeconds` to `expiresIn`.

This change does not affect to users of this library, a revision/patch version number increase would be enough.

Can you create a new version?